### PR TITLE
Version SDK bumped to 2.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ all:
 
 .PHONY: install
 install:
+	composer update
 	composer install --prefer-dist --no-interaction
 
 .PHONY: coveralls

--- a/src/SDK.php
+++ b/src/SDK.php
@@ -12,7 +12,7 @@ use RingCentral\SDK\Subscription\Subscription;
 class SDK
 {
 
-    const VERSION = '2.1.0';
+    const VERSION = '2.1.1';
     const SERVER_PRODUCTION = 'https://platform.ringcentral.com';
     const SERVER_SANDBOX = 'https://platform.devtest.ringcentral.com';
 


### PR DESCRIPTION
1.) SDK Version Bump to -> `2.1.1`

2.) Error Fix for `phpunit/php-token-stream` as complained in the [PR](https://github.com/ringcentral/ringcentral-php/pull/47/commits/793f4d50ecae7cbf6d1ed2114352751933e78e1c)
```
Problem 1
    - Installation request for phpunit/php-token-stream 2.0.0 -> satisfiable by phpunit/php-token-stream[2.0.0].
    - phpunit/php-token-stream 2.0.0 requires php ^7.0 -> your PHP version (5.6.30) does not satisfy that requirement.
  Problem 2
    - phpunit/php-token-stream 2.0.0 requires php ^7.0 -> your PHP version (5.6.30) does not satisfy that requirement.
    - phpunit/php-code-coverage 4.0.8 requires phpunit/php-token-stream ^1.4.2 || ^2.0 -> satisfiable by phpunit/php-token-stream[2.0.0].
    - Installation request for phpunit/php-code-coverage 4.0.8 -> satisfiable by phpunit/php-code-coverage[4.0.8].
```