### PR TITLE
Update symfony/event-dispatcher to support lavavel 5.6.* and 5.7.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "php": ">=5.6.0",
     "guzzlehttp/psr7": "^1.4.2",
     "pubnub/pubnub": "^4.0.0",
-    "symfony/event-dispatcher": "^2.7|^3.3.2",
+    "symfony/event-dispatcher": "^2.7|^3.3.2|^4.0",
     "guzzlehttp/guzzle": "^6.2.3"
   },
   "require-dev": {


### PR DESCRIPTION
Update symfony/event-dispatcher versions to ^2.7|^3.3.2|^4.0 to support Lavavel 5.6.* and 5.7.*

Fixes #71