### PR TITLE
Multipart issue with newlines

### DIFF
--- a/src/Http/ApiResponse.php
+++ b/src/Http/ApiResponse.php
@@ -143,7 +143,7 @@ class ApiResponse
 
             $parts = explode('--' . $boundary . '', $this->text()); //TODO Handle as stream
 
-            if (empty($parts[0])) {
+            if (empty(trim($parts[0]))) {
                 array_shift($parts);
             }
 


### PR DESCRIPTION
When the multipart response has a new line (\n) or tab (\t) character on the first line of the response an exception will be thrown. 

```Invalid message: Missing header delimiter```

PHP documentation: http://php.net/manual/en/function.empty.php does not consider \n or \t empty

When calling `/glip/persons/{users_id, user_id2, etc}` returns a multipart stream with a new line at the beginning of the stream.

