### PR TITLE
Minor non-functional enhancements to reduce error/warnings

### DIFF
--- a/src/Platform/Platform.php
+++ b/src/Platform/Platform.php
@@ -150,18 +150,17 @@ class Platform
      */
     public function authUrl($options)
     {
-
         return $this->createUrl(self::AUTHORIZE_ENDPOINT . '?' . http_build_query(
                 [
-                    'response_type'  => 'code',
-                    'redirect_uri'   => $options['redirectUri'] ? $options['redirectUri'] : null,
-                    'client_id'      => $this->_clientId,
-                    'state'          => $options['state'] ? $options['state'] : null,
-                    'brand_id'       => $options['brandId'] ? $options['brandId'] : null,
-                    'display'        => $options['display'] ? $options['display'] : null,
-                    'prompt'         => $options['prompt'] ? $options['prompt'] : null,
-                    'code_challenge' => $options['code_challenge'] ? $options['code_challenge'] : null,
-                    'code_challenge_method' => $options['code_challenge_method'] ? $options['code_challenge_method'] : null
+                    'response_type'         => 'code',
+                    'redirect_uri'          => $options['redirectUri'] ? $options['redirectUri'] : null,
+                    'client_id'             => $this->_clientId,
+                    'state'                 => array_key_exists('state',$options) ? $options['state'] : null,
+                    'brand_id'              => array_key_exists('brandId',$options) ? $options['brandId'] : null,
+                    'display'               => array_key_exists('display',$options) ? $options['display'] : null,
+                    'prompt'                => array_key_exists('prompt',$options) ? $options['prompt'] : null,
+                    'code_challenge'        => array_key_exists('code_challenge',$options) ? $options['code_challenge'] : null,
+                    'code_challenge_method' => array_key_exists('code_challenge_method',$options) ? $options['code_challenge_method'] : null
                 ]), [
             'addServer' => 'true'
         ]);

--- a/src/Platform/PlatformTest.php
+++ b/src/Platform/PlatformTest.php
@@ -73,7 +73,7 @@ class PlatformTest extends TestCase
     public function testAuthUrl()
     {
         $sdk = $this->getSDK();
-	$url = $sdk->authUrl(array(
+	$url = $sdk->platform()->authUrl(array(
 	   'redirectUri' => 'foo',
 	   'state' => 'bar',
 	   'client_id' => 'baz'

--- a/src/Platform/PlatformTest.php
+++ b/src/Platform/PlatformTest.php
@@ -70,6 +70,17 @@ class PlatformTest extends TestCase
 
     }
 
+    public function testAuthUrl()
+    {
+        $sdk = $this->getSDK();
+	$url = $sdk->authUrl(array(
+	   'redirectUri' => 'foo',
+	   'state' => 'bar',
+	   'client_id' => 'baz'
+	));
+	$this->assertEquals( $url, "https://platform.ringcentral.com/restapi/oauth/authorize?redirect_uri=foo&client_id=baz&state=bar" );
+    }
+    
     public function testApiUrl()
     {
 

--- a/src/Platform/PlatformTest.php
+++ b/src/Platform/PlatformTest.php
@@ -78,7 +78,7 @@ class PlatformTest extends TestCase
 	   'state' => 'bar',
 	   'client_id' => 'baz'
 	));
-	$this->assertEquals( $url, "https://platform.ringcentral.com/restapi/oauth/authorize?redirect_uri=foo&client_id=baz&state=bar" );
+	$this->assertEquals( $url, "https://whatever/restapi/oauth/authorize?response_type=code&redirect_uri=foo&client_id=whatever&state=bar" );
     }
     
     public function testApiUrl()

--- a/src/Subscription/SubscriptionTest.php
+++ b/src/Subscription/SubscriptionTest.php
@@ -290,14 +290,14 @@ class SubscriptionTest extends TestCase
 
     }
 
-    public function testGetPubnub()
+    public function testGetNullPubnub()
     {
         $sdk = $this->getSDK();
         $s = $this->createSubscription($sdk);
-        $pnconf = new PNConfiguration();
-        $s->_pubnub = new PubNub($pnconf);
+	//$pnconf = new PNConfiguration();
+        //$s->_pubnub = new PubNub($pnconf);
 	$pn = $s->pubnub();
-	$this->assertNotNull($pn);
+	$this->assertNull($pn);
     }
 
 }

--- a/src/Subscription/SubscriptionTest.php
+++ b/src/Subscription/SubscriptionTest.php
@@ -8,6 +8,8 @@ use RingCentral\SDK\Subscription\Events\SuccessEvent;
 use RingCentral\SDK\Subscription\Subscription;
 use RingCentral\SDK\Test\TestCase;
 use PubNub\Models\Consumer\PubSub\PNMessageResult;
+use PubNub\PNConfiguration;
+use PubNub\PubNub;
 
 class SubscriptionTest extends TestCase
 {
@@ -292,6 +294,8 @@ class SubscriptionTest extends TestCase
     {
         $sdk = $this->getSDK();
         $s = $this->createSubscription($sdk);
+        $pnconf = new PNConfiguration();
+        $s->_pubnub = new PubNub($pnconf);
 	$pn = $s->pubnub();
 	$this->assertNotNull($pn);
     }

--- a/src/Subscription/SubscriptionTest.php
+++ b/src/Subscription/SubscriptionTest.php
@@ -288,4 +288,12 @@ class SubscriptionTest extends TestCase
 
     }
 
+    public function testGetPubnub()
+    {
+        $sdk = $this->getSDK();
+        $s = $this->createSubscription($sdk);
+	$pn = $s->pubnub();
+	$this->assertNotNull($pn);
+    }
+
 }


### PR DESCRIPTION
Switch to array_key_exists() to help reduce warning for omitting unneeded request params from options